### PR TITLE
feat: update library versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Gradle Kotlin DSL
 
 ```kotlin
 repositories {
-  jcenter()
+  mavenCentral()
   maven("https://jitpack.io")
 }
 dependencies {
@@ -130,7 +130,7 @@ Gradle Kotlin DSL
 
 ```kotlin
 repositories {
-  jcenter()
+  mavenCentral()
   maven("https://jitpack.io")
 }
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ tasks.getByName<Wrapper>("wrapper") {
 
 subprojects {
   repositories {
-    jcenter()
+    mavenCentral()
   }
 
   tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 tasks.getByName<Wrapper>("wrapper") {
-  gradleVersion = "5.5.1"
+  gradleVersion = "6.8.3"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.3.41" apply false
+  kotlin("jvm") version "1.4.32" apply false
 }
 
 tasks.getByName<Wrapper>("wrapper") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,6 +11,5 @@ tasks.withType<KotlinCompile> {
 }
 
 repositories {
-  // Current Kotlin DSL need JCenter to resolve stdlib for buildSrc compilation
-  jcenter()
+  mavenCentral()
 }

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -4,4 +4,4 @@ fun jacksonKotlinModule() = "com.fasterxml.jackson.module:jackson-module-kotlin:
 
 fun guava() = "com.google.guava:guava:28.0-jre"
 
-fun kotlinTestJUnit5Runner() = "io.kotlintest:kotlintest-runner-junit5:3.4.0"
+fun kotlinTestJUnit5Runner() = "io.kotest:kotest-runner-junit5-jvm:4.4.3"

--- a/buildSrc/src/main/kotlin/versions.kt
+++ b/buildSrc/src/main/kotlin/versions.kt
@@ -1,2 +1,2 @@
 
-const val jackson_version = "2.9.9"
+const val jackson_version = "2.12.3"

--- a/enumerated/src/test/kotlin/jp/justincase/jackson/kotlin/enumerated/test/EnumeratedSpec.kt
+++ b/enumerated/src/test/kotlin/jp/justincase/jackson/kotlin/enumerated/test/EnumeratedSpec.kt
@@ -1,8 +1,8 @@
 package jp.justincase.jackson.kotlin.enumerated.test
 
-import io.kotlintest.should
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.StringSpec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.enumerated.Enumerated
 import jp.justincase.jackson.kotlin.enumerated.values
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/numerical-codec/src/test/kotlin/jp/justincase/jackson/kotlin/numerical/test/ExampleSpec.kt
+++ b/numerical-codec/src/test/kotlin/jp/justincase/jackson/kotlin/numerical/test/ExampleSpec.kt
@@ -1,3 +1,4 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
 package jp.justincase.jackson.kotlin.numerical.test
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/numerical-codec/src/test/kotlin/jp/justincase/jackson/kotlin/numerical/test/ExampleSpec.kt
+++ b/numerical-codec/src/test/kotlin/jp/justincase/jackson/kotlin/numerical/test/ExampleSpec.kt
@@ -3,9 +3,9 @@ package jp.justincase.jackson.kotlin.numerical.test
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldThrow
-import io.kotlintest.specs.StringSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.numerical.Numerical
 import jp.justincase.jackson.kotlin.numerical.codec.NumericalModule
 import java.math.BigDecimal

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/CustomTypeNameExampleSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/CustomTypeNameExampleSpec.kt
@@ -2,8 +2,8 @@ package jp.justincase.jackson.kotlin.polymorphic.test
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.StringSpec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.polymorphic.Polymorphic
 import jp.justincase.jackson.kotlin.polymorphic.codec.PolymorphicModule
 import kotlin.reflect.KClass

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/CustomTypeNameExampleSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/CustomTypeNameExampleSpec.kt
@@ -1,3 +1,4 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
 package jp.justincase.jackson.kotlin.polymorphic.test
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/ExampleSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/ExampleSpec.kt
@@ -1,3 +1,4 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
 package jp.justincase.jackson.kotlin.polymorphic.test
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/ExampleSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/ExampleSpec.kt
@@ -2,8 +2,8 @@ package jp.justincase.jackson.kotlin.polymorphic.test
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.StringSpec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.polymorphic.Polymorphic
 import jp.justincase.jackson.kotlin.polymorphic.codec.PolymorphicModule
 

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicGenericsSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicGenericsSpec.kt
@@ -2,8 +2,8 @@ package jp.justincase.jackson.kotlin.polymorphic.test
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.WordSpec
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.polymorphic.Polymorphic
 import jp.justincase.jackson.kotlin.polymorphic.codec.PolymorphicModule
 

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicGenericsSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicGenericsSpec.kt
@@ -1,3 +1,4 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
 package jp.justincase.jackson.kotlin.polymorphic.test
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicSpec.kt
@@ -3,9 +3,9 @@ package jp.justincase.jackson.kotlin.polymorphic.test
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldThrow
-import io.kotlintest.specs.WordSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.polymorphic.Polymorphic
 import jp.justincase.jackson.kotlin.polymorphic.codec.PolymorphicModule
 

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicSpec.kt
@@ -1,3 +1,4 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
 package jp.justincase.jackson.kotlin.polymorphic.test
 
 import com.fasterxml.jackson.databind.exc.MismatchedInputException

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicSpecialCaseSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicSpecialCaseSpec.kt
@@ -3,9 +3,9 @@ package jp.justincase.jackson.kotlin.polymorphic.test
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldThrow
-import io.kotlintest.specs.WordSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.polymorphic.Polymorphic
 import jp.justincase.jackson.kotlin.polymorphic.codec.PolymorphicModule
 

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicSpecialCaseSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicSpecialCaseSpec.kt
@@ -1,3 +1,4 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
 package jp.justincase.jackson.kotlin.polymorphic.test
 
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicTypeNameSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicTypeNameSpec.kt
@@ -1,3 +1,4 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
 package jp.justincase.jackson.kotlin.polymorphic.test
 
 import com.fasterxml.jackson.databind.JsonMappingException

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicTypeNameSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/PolymorphicTypeNameSpec.kt
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldThrow
-import io.kotlintest.specs.WordSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.polymorphic.Polymorphic
 import jp.justincase.jackson.kotlin.polymorphic.codec.PolymorphicModule
 import kotlin.reflect.KClass

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/WrappedObjectExampleSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/WrappedObjectExampleSpec.kt
@@ -1,3 +1,4 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
 package jp.justincase.jackson.kotlin.polymorphic.test
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper

--- a/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/WrappedObjectExampleSpec.kt
+++ b/polymorphic-codec/src/test/kotlin/jp/justincase/jackson/kotlin/polymorphic/test/WrappedObjectExampleSpec.kt
@@ -2,8 +2,8 @@ package jp.justincase.jackson.kotlin.polymorphic.test
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.StringSpec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.polymorphic.Polymorphic
 import jp.justincase.jackson.kotlin.polymorphic.codec.PolymorphicModule
 

--- a/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/EnumeratedTextualSpec.kt
+++ b/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/EnumeratedTextualSpec.kt
@@ -1,11 +1,9 @@
 package jp.justincase.jackson.kotlin.textual.test
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldThrow
-import io.kotlintest.specs.StringSpec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.enumerated.Enumerated
 import jp.justincase.jackson.kotlin.textual.codec.TextualModule
 

--- a/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/EnumeratedTextualSpec.kt
+++ b/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/EnumeratedTextualSpec.kt
@@ -1,3 +1,4 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
 package jp.justincase.jackson.kotlin.textual.test
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/ExampleSpec.kt
+++ b/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/ExampleSpec.kt
@@ -2,8 +2,8 @@ package jp.justincase.jackson.kotlin.textual.test
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.StringSpec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.textual.Textual
 import jp.justincase.jackson.kotlin.textual.codec.TextualModule
 

--- a/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/ExampleSpec.kt
+++ b/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/ExampleSpec.kt
@@ -1,3 +1,4 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
 package jp.justincase.jackson.kotlin.textual.test
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/TextualGenericSpec.kt
+++ b/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/TextualGenericSpec.kt
@@ -1,3 +1,4 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
 package jp.justincase.jackson.kotlin.textual.test
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/TextualGenericSpec.kt
+++ b/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/TextualGenericSpec.kt
@@ -2,8 +2,8 @@ package jp.justincase.jackson.kotlin.textual.test
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.WordSpec
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.textual.Textual
 import jp.justincase.jackson.kotlin.textual.codec.TextualModule
 

--- a/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/TextualSpec.kt
+++ b/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/TextualSpec.kt
@@ -1,3 +1,4 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
 package jp.justincase.jackson.kotlin.textual.test
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/TextualSpec.kt
+++ b/textual-codec/src/test/kotlin/jp/justincase/jackson/kotlin/textual/test/TextualSpec.kt
@@ -3,9 +3,9 @@ package jp.justincase.jackson.kotlin.textual.test
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldThrow
-import io.kotlintest.specs.StringSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import jp.justincase.jackson.kotlin.textual.Textual
 import jp.justincase.jackson.kotlin.textual.TextualEncoder
 import jp.justincase.jackson.kotlin.textual.codec.TextualModule


### PR DESCRIPTION
## TL;DR
- replace maven repository resolver from `jcenter` to `maven central`
- update gradle version to `6.8.3`
- update kotlin version to `1.4.32`
- update jackson version to `2.12.3`
- update kotest (kotlintest) version to `4.4.3`
- suppress `BlockingMethodInNonBlockingContext`